### PR TITLE
Handles 422 app create response when an account is unverified. Fixes #68

### DIFF
--- a/com.heroku.eclipse.core.services.rest/src/com/heroku/eclipse/core/services/rest/RestHerokuSession.java
+++ b/com.heroku.eclipse.core.services.rest/src/com/heroku/eclipse/core/services/rest/RestHerokuSession.java
@@ -47,6 +47,11 @@ public class RestHerokuSession implements HerokuSession {
 	private static Pattern PATTERN_NOT_ALLOWED = Pattern.compile(".*(The owner of.*must be verified before you can scale processes|only the owner|Only the app owner).*"); //$NON-NLS-1$
 	
 	/**
+	 * Pattern for checking if an account is unverified
+	 */
+	private static Pattern PATTERN_VERIFY_ACCOUNT = Pattern.compile(".*(Please verify your account to install this add-on).*");
+	
+	/**
 	 * @param apiKey
 	 */
 	public RestHerokuSession(String apiKey) {
@@ -91,6 +96,9 @@ public class RestHerokuSession implements HerokuSession {
 				}
 				else if (PATTERN_NOT_ALLOWED.matcher(e.getResponseBody()).matches()) {
 					return new HerokuServiceException(HerokuServiceException.NOT_ALLOWED, extractErrorField(e.getResponseBody()), e);
+				}
+				else if (PATTERN_VERIFY_ACCOUNT.matcher(e.getResponseBody()).matches()) {
+					return new HerokuServiceException(HerokuServiceException.UNVERIFIED, extractErrorField(e.getResponseBody()), e);
 				}
 				else {
 					return new HerokuServiceException(HerokuServiceException.REQUEST_FAILED, extractErrorField(e.getResponseBody()), e);

--- a/com.heroku.eclipse.core.services/src/com/heroku/eclipse/core/services/exceptions/HerokuServiceException.java
+++ b/com.heroku.eclipse.core.services/src/com/heroku/eclipse/core/services/exceptions/HerokuServiceException.java
@@ -86,6 +86,11 @@ public class HerokuServiceException extends Exception {
 	 */
 	public static final int OPERATION_CANCELLED = 15;
 	
+	/**
+	 * indicates the account is unverified
+	 */
+	public static final int UNVERIFIED = 16;
+	
 	private final int errorCode;
 
 	public HerokuServiceException(Throwable t) {

--- a/com.heroku.eclipse.ui/i18n/messages.properties
+++ b/com.heroku.eclipse.ui/i18n/messages.properties
@@ -52,6 +52,7 @@ HerokuAppCreateNamePage_Error_NameAlreadyExists=Application name either already 
 HerokuAppCreateNamePage_Error_NameAlreadyExists_Hint=Name should be unique, be at least 2 characters, begin with a letter & only contain letters, numbers and dashes
 HerokuAppCreateNamePage_Error_GitLocationInvalid_Title=Git location invalid
 HerokuAppCreateNamePage_Error_GitLocationInvalid=Git location for new App is invalid or already exists: ''{0}''
+HerokuAppCreateNamePage_Error_UnverifiedAccount=Your account is unverified and cannot create the requested app. Please visit https://dashboard.heroku.com/account to verify.
 
 HerokuAppCreateTemplatePage_Title=Select an application template for your new Heroku App
 HerokuAppCreateTemplatePage_Description=Application name is optional. The name should be unique, be at least 2 characters, begin with a letter & only contain letters, numbers and dashes

--- a/com.heroku.eclipse.ui/src/com/heroku/eclipse/ui/wizards/HerokuAppCreate.java
+++ b/com.heroku.eclipse.ui/src/com/heroku/eclipse/ui/wizards/HerokuAppCreate.java
@@ -124,6 +124,10 @@ public class HerokuAppCreate extends Wizard implements IImportWizard {
 						Activator.getDefault().getLogger().log(LogService.LOG_WARNING, "Application '" + appName + "' already exists, denying creation", e); //$NON-NLS-1$ //$NON-NLS-2$
 						createPage.displayInvalidNameWarning();
 					}
+					else if (e1.getErrorCode() == HerokuServiceException.UNVERIFIED) {
+						Activator.getDefault().getLogger().log(LogService.LOG_WARNING, "Account is unverified and cannot create " + template.getTemplateName(), e); //$NON-NLS-1$ //$NON-NLS-2$
+						createPage.displayUnverifiedAccountWarning();
+					}
 					else if (e1.getErrorCode() == HerokuServiceException.INVALID_LOCAL_GIT_LOCATION) {
 						HerokuUtils
 								.userError(

--- a/com.heroku.eclipse.ui/src/com/heroku/eclipse/ui/wizards/HerokuAppCreatePage.java
+++ b/com.heroku.eclipse.ui/src/com/heroku/eclipse/ui/wizards/HerokuAppCreatePage.java
@@ -364,4 +364,13 @@ public class HerokuAppCreatePage extends WizardPage {
 		setErrorMessage(Messages.getString("HerokuAppCreateNamePage_Error_NameAlreadyExists")); //$NON-NLS-1$
 		tAppName.setFocus();
 	}
+	
+	/**
+	 * Displays a warning about an unverified account
+	 */
+	public void displayUnverifiedAccountWarning() {
+		setVisible(true);
+		setErrorMessage(Messages.getString("HerokuAppCreateNamePage_Error_UnverifiedAccount")); //$NON-NLS-1$
+		tAppName.setFocus();
+	}
 }


### PR DESCRIPTION
This pr handles the case where an app clone might have addons that an unverified account cannot use. Shows an error message instead of crapping out.

@jsimone can you review?
